### PR TITLE
Features/reduce texture memory

### DIFF
--- a/Scripts/Editor/Batchers/MaterialPreservingBatcher.cs
+++ b/Scripts/Editor/Batchers/MaterialPreservingBatcher.cs
@@ -9,15 +9,21 @@ namespace UnityEditor.Experimental.AutoLOD
     /// </summary>
     class MaterialPreservingBatcher : IBatcher
     {
-        public IEnumerator Batch(GameObject go)
+        public IEnumerator Batch(GameObject hlodRoot)
         {
-            var renderers = go.GetComponentsInChildren<Renderer>();
-            foreach (var r in renderers)
+            foreach (Transform child in hlodRoot.transform)
             {
-                r.enabled = true;
+                var go = child.gameObject;
+                var renderers = go.GetComponentsInChildren<Renderer>();
+                foreach (var r in renderers)
+                {
+                    r.enabled = true;
+                    yield return null;
+                }
+
+                StaticBatchingUtility.Combine(go);
                 yield return null;
             }
-            StaticBatchingUtility.Combine(go);
         }
     }
 }

--- a/Scripts/Editor/Batchers/SimpleBatcher.cs
+++ b/Scripts/Editor/Batchers/SimpleBatcher.cs
@@ -37,153 +37,186 @@ namespace UnityEditor.Experimental.AutoLOD
         }
 
         Texture2D m_WhiteTexture;
+        private TexturePacker packer = new TexturePacker();
 
-        public IEnumerator Batch(GameObject go)
+        Texture2D GetTexture(Material m)
         {
-            var renderers = go.GetComponentsInChildren<Renderer>();
-            var materials = new HashSet<Material>(renderers.SelectMany(r => r.sharedMaterials));
-
-            //foreach (var material in materials) { Debug.Log(material); }
-            var textures = new HashSet<Texture2D>(materials.Select(m =>
+            if (m)
             {
-                if (m)
+                if ( m.mainTexture != null)
                     return m.mainTexture as Texture2D;
-
-                return null;
-            }).Where(t => t != null)).ToList();
-            textures.Add(whiteTexture);
-
-            TextureAtlas atlas = null;
-            yield return TextureAtlasModule.instance.GetTextureAtlas(textures.ToArray(), a => atlas = a);
-
-            var atlasLookup = new Dictionary<Texture2D, Rect>();
-            var atlasTextures = atlas.textures;
-            for (int i = 0; i < atlasTextures.Length; i++)
-            {
-                atlasLookup[atlasTextures[i]] = atlas.uvs[i];
-            }
-
-            MeshFilter[] meshFilters = go.GetComponentsInChildren<MeshFilter>();
-            var combine = new List<CombineInstance>();
-            for (int i = 0; i < meshFilters.Length; i++)
-            {
-                var mf = meshFilters[i];
-                var sharedMesh = mf.sharedMesh;
-
-                if (!sharedMesh)
-                    continue;
-
-                if (!sharedMesh.isReadable)
-                {
-                    var assetPath = AssetDatabase.GetAssetPath(sharedMesh);
-                    if (!string.IsNullOrEmpty(assetPath))
-                    {
-                        var importer = AssetImporter.GetAtPath(assetPath) as ModelImporter;
-                        if (importer)
-                        {
-                            importer.isReadable = true;
-                            importer.SaveAndReimport();
-                        }
-                    }
-                }
-
-                var mesh = Object.Instantiate(sharedMesh);
-
-                var mr = mf.GetComponent<MeshRenderer>();
-                var sharedMaterials = mr.sharedMaterials;
-                var uv = mesh.uv;
-                var colors = mesh.colors;
-                if (colors == null || colors.Length == 0)
-                    colors = new Color[uv.Length];
-                var updated = new bool[uv.Length];
-                var triangles = new List<int>();
-
-                // Some meshes have submeshes that either aren't expected to render or are missing a material, so go ahead and skip
-                var subMeshCount = Mathf.Min(mesh.subMeshCount, sharedMaterials.Length);
-                for (int j = 0; j < subMeshCount; j++)
-                {
-                    var sharedMaterial = sharedMaterials[Mathf.Min(j, sharedMaterials.Length - 1)];
-                    var mainTexture = whiteTexture;
-                    var materialColor = Color.white;
-
-                    if (sharedMaterial)
-                    {
-                        var texture = sharedMaterial.mainTexture as Texture2D;
-                        if (texture)
-                            mainTexture = texture;
-
-                        if (sharedMaterial.HasProperty("_Color"))
-                            materialColor = sharedMaterial.color;
-                    }
-
-                    if (mesh.GetTopology(j) != MeshTopology.Triangles)
-                    {
-                        Debug.LogWarning("Mesh must have triangles", mf);
-                        continue;
-                    }
-
-                    triangles.Clear();
-                    mesh.GetTriangles(triangles, j);
-                    var uvOffset = atlasLookup[mainTexture];
-                    foreach (var t in triangles)
-                    {
-                        if (!updated[t])
-                        {
-                            var uvCoord = uv[t];
-                            if (mainTexture == whiteTexture)
-                            {
-                                // Sample at center of white texture to avoid sampling edge colors incorrectly
-                                uvCoord.x = 0.5f;
-                                uvCoord.y = 0.5f;
-                            }
-
-                            uvCoord.x = Mathf.Lerp(uvOffset.xMin, uvOffset.xMax, uvCoord.x);
-                            uvCoord.y = Mathf.Lerp(uvOffset.yMin, uvOffset.yMax, uvCoord.y);
-                            uv[t] = uvCoord;
-
-                            if (mainTexture == whiteTexture)
-                                colors[t] = materialColor;
-                            else
-                                colors[t] = Color.white;
-
-                            updated[t] = true;
-                        }
-                    }
-                }
-                mesh.uv = uv;
-                mesh.uv2 = null;
-                mesh.colors = colors;
-
-                for (int j = 0; j < subMeshCount; ++j)
-                {
-                    var ci = new CombineInstance();
-                    ci.mesh = mesh;
-                    ci.subMeshIndex = j;
-                    ci.transform = mf.transform.localToWorldMatrix;
-                    combine.Add(ci);
-                }
                 
-
-                mf.gameObject.SetActive(false);
             }
-            var combinedMesh = new Mesh();
-#if UNITY_2017_3_OR_NEWER
-            combinedMesh.indexFormat = IndexFormat.UInt32;
-#endif
-            combinedMesh.CombineMeshes(combine.ToArray(), true, true);
-            combinedMesh.RecalculateBounds();
-            var meshFilter = go.AddComponent<MeshFilter>();
-            meshFilter.sharedMesh = combinedMesh;
 
-            for (int i = 0; i < meshFilters.Length; i++)
+            return null;
+        }
+
+        public IEnumerator Batch(GameObject hlodRoot)
+        {
+            yield return PackTextures(hlodRoot);
+
+            foreach (Transform child in hlodRoot.transform)
             {
-                Object.DestroyImmediate(meshFilters[i].gameObject);
+                var go = child.gameObject;
+                var renderers = go.GetComponentsInChildren<Renderer>();
+                var materials = new HashSet<Material>(renderers.SelectMany(r => r.sharedMaterials));
+
+                TextureAtlas atlas = packer.GetAtlas(go);
+
+                var atlasLookup = new Dictionary<Texture2D, Rect>();
+                var atlasTextures = atlas.textures;
+                for (int i = 0; i < atlasTextures.Length; i++)
+                {
+                    atlasLookup[atlasTextures[i]] = atlas.uvs[i];
+                }
+
+                MeshFilter[] meshFilters = go.GetComponentsInChildren<MeshFilter>();
+                var combine = new List<CombineInstance>();
+                for (int i = 0; i < meshFilters.Length; i++)
+                {
+                    var mf = meshFilters[i];
+                    var sharedMesh = mf.sharedMesh;
+
+                    if (!sharedMesh)
+                        continue;
+
+                    if (!sharedMesh.isReadable)
+                    {
+                        var assetPath = AssetDatabase.GetAssetPath(sharedMesh);
+                        if (!string.IsNullOrEmpty(assetPath))
+                        {
+                            var importer = AssetImporter.GetAtPath(assetPath) as ModelImporter;
+                            if (importer)
+                            {
+                                importer.isReadable = true;
+                                importer.SaveAndReimport();
+                            }
+                        }
+                    }
+
+                    var mesh = Object.Instantiate(sharedMesh);
+
+                    var mr = mf.GetComponent<MeshRenderer>();
+                    var sharedMaterials = mr.sharedMaterials;
+                    var uv = mesh.uv;
+                    var colors = mesh.colors;
+                    if (colors == null || colors.Length == 0)
+                        colors = new Color[uv.Length];
+                    var updated = new bool[uv.Length];
+                    var triangles = new List<int>();
+
+                    // Some meshes have submeshes that either aren't expected to render or are missing a material, so go ahead and skip
+                    var subMeshCount = Mathf.Min(mesh.subMeshCount, sharedMaterials.Length);
+                    for (int j = 0; j < subMeshCount; j++)
+                    {
+                        var sharedMaterial = sharedMaterials[Mathf.Min(j, sharedMaterials.Length - 1)];
+                        var mainTexture = whiteTexture;
+                        var materialColor = Color.white;
+
+                        if (sharedMaterial)
+                        {
+                            var texture = GetTexture(sharedMaterial);
+                            if (texture)
+                                mainTexture = texture;
+
+                            if (sharedMaterial.HasProperty("_Color"))
+                                materialColor = sharedMaterial.color;
+                        }
+
+                        if (mesh.GetTopology(j) != MeshTopology.Triangles)
+                        {
+                            Debug.LogWarning("Mesh must have triangles", mf);
+                            continue;
+                        }
+
+                        triangles.Clear();
+                        mesh.GetTriangles(triangles, j);
+                        var uvOffset = atlasLookup[mainTexture];
+                        foreach (var t in triangles)
+                        {
+                            if (!updated[t])
+                            {
+                                var uvCoord = uv[t];
+                                if (mainTexture == whiteTexture)
+                                {
+                                    // Sample at center of white texture to avoid sampling edge colors incorrectly
+                                    uvCoord.x = 0.5f;
+                                    uvCoord.y = 0.5f;
+                                }
+
+                                uvCoord.x = Mathf.Lerp(uvOffset.xMin, uvOffset.xMax, uvCoord.x);
+                                uvCoord.y = Mathf.Lerp(uvOffset.yMin, uvOffset.yMax, uvCoord.y);
+                                uv[t] = uvCoord;
+
+                                if (mainTexture == whiteTexture)
+                                    colors[t] = materialColor;
+                                else
+                                    colors[t] = Color.white;
+
+                                updated[t] = true;
+                            }
+                        }
+                    }
+
+                    mesh.uv = uv;
+                    mesh.uv2 = null;
+                    mesh.colors = colors;
+
+                    for (int j = 0; j < subMeshCount; ++j)
+                    {
+                        var ci = new CombineInstance();
+                        ci.mesh = mesh;
+                        ci.subMeshIndex = j;
+                        ci.transform = mf.transform.localToWorldMatrix;
+                        combine.Add(ci);
+                    }
+
+
+                    mf.gameObject.SetActive(false);
+                }
+
+                var combinedMesh = new Mesh();
+#if UNITY_2017_3_OR_NEWER
+                combinedMesh.indexFormat = IndexFormat.UInt32;
+#endif
+                combinedMesh.CombineMeshes(combine.ToArray(), true, true);
+                combinedMesh.RecalculateBounds();
+                var meshFilter = go.AddComponent<MeshFilter>();
+                meshFilter.sharedMesh = combinedMesh;
+
+                for (int i = 0; i < meshFilters.Length; i++)
+                {
+                    Object.DestroyImmediate(meshFilters[i].gameObject);
+                }
+
+                var meshRenderer = go.AddComponent<MeshRenderer>();
+                var material = new Material(Shader.Find("Custom/AutoLOD/SimpleBatcher"));
+                material.mainTexture = atlas.textureAtlas;
+                meshRenderer.sharedMaterial = material;
+            }
+        }
+
+        private IEnumerator PackTextures(GameObject hlodRoot)
+        {
+            foreach (Transform child in hlodRoot.transform)
+            {
+                var renderers = child.GetComponentsInChildren<Renderer>();
+                var materials = new HashSet<Material>(renderers.SelectMany(r => r.sharedMaterials));
+
+                var textures =
+                    new HashSet<Texture2D>(
+                        materials
+                            .Select(GetTexture)
+                            .Where(t => t != null))
+                        .ToList();
+
+                textures.Add(whiteTexture);
+
+                packer.AddTextureGroup(child.gameObject, textures.ToArray());
+                yield return null;
             }
 
-            var meshRenderer = go.AddComponent<MeshRenderer>();
-            var material = new Material(Shader.Find("Custom/AutoLOD/SimpleBatcher"));
-            material.mainTexture = atlas.textureAtlas;
-            meshRenderer.sharedMaterial = material;
+            yield return packer.Pack(1024, 256);
         }
     }
 }

--- a/Scripts/Editor/TexturePacker.cs
+++ b/Scripts/Editor/TexturePacker.cs
@@ -1,0 +1,187 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace UnityEditor.Experimental.AutoLOD
+{
+    public class TexturePacker
+    {
+        public TexturePacker()
+        {
+
+        }
+
+        public void  AddTextureGroup(GameObject go, Texture2D[] textures)
+        {
+            Group group = new Group();
+            group.go = go;
+            group.textures = new HashSet<Texture2D>(textures);
+
+            groups.Add(group);
+        }
+
+        public TextureAtlas GetAtlas(GameObject go)
+        {
+            foreach (var group in atlasGroups)
+            {
+                if (group.GameObjects.Contains(go))
+                    return group.Atlas;
+            }
+            return null;
+        }
+
+        class PackTexture
+        {
+            public List<GameObject> GameObjects;
+            public HashSet<Texture2D> Textures;
+
+            
+        }
+
+        class Score
+        {
+            public PackTexture Lhs;
+            public PackTexture Rhs;
+            public int Match;
+
+            public static Score GetScore(PackTexture lhs, PackTexture rhs)
+            {
+                int match = lhs.Textures.Intersect(rhs.Textures).Count();
+                return new Score()
+                {
+                    Lhs = lhs,
+                    Rhs = rhs,
+                    Match = match
+                };
+            }
+        }
+        class Group
+        {
+            public GameObject go;
+            public HashSet<Texture2D> textures;
+        }
+
+        class AtlasGroup
+        {
+            public List<GameObject> GameObjects;
+            public TextureAtlas Atlas;
+        }
+
+        List<Group> groups = new List<Group>();
+        List<AtlasGroup> atlasGroups = new List<AtlasGroup>();
+
+
+        public IEnumerator Pack(int packTextureSize, int maxPieceSize)
+        {
+            //First, we should separate each group by count.
+            Dictionary<int, List<Group>> groupCluster = new Dictionary<int, List<Group>>();
+
+            for (int i = 0; i < groups.Count; ++i)
+            {
+                Group group = groups[i];
+                int maximum = GetMaximumTextureCount(packTextureSize, maxPieceSize, group.textures.Count);
+                if ( groupCluster.ContainsKey(maximum) == false )
+                    groupCluster[maximum] = new List<Group>();
+
+                groupCluster[maximum].Add(group);
+            }
+
+            //Second, we should figure out which group should be combined from each cluster.
+            foreach (var cluster in groupCluster)
+            {
+                int maximum = cluster.Key;
+                List<PackTexture> packTextures = new List<PackTexture>();
+
+                foreach (var group in cluster.Value)
+                {
+                    packTextures.Add(new PackTexture()
+                    {
+                        GameObjects = new List<GameObject>() {group.go},
+                        Textures = new HashSet<Texture2D>(group.textures)
+
+                    });                    
+                }
+
+                List<Score> scoreList = new List<Score>();
+                for (int i = 0; i < packTextures.Count; ++i)
+                {
+                    for (int j = i + 1; j < packTextures.Count; ++j)
+                    {
+                        scoreList.Add(Score.GetScore(packTextures[i], packTextures[j]));
+                    }
+                }
+
+                scoreList.Sort((lhs, rhs) => rhs.Match - lhs.Match);
+
+                for (int i = 0; i < scoreList.Count; ++i)
+                {
+                    HashSet<Texture2D> unionTextures = new HashSet<Texture2D>(scoreList[i].Lhs.Textures.Union(scoreList[i].Rhs.Textures));
+                    if (unionTextures.Count <= maximum)
+                    {
+                        PackTexture lhs = scoreList[i].Lhs;
+                        PackTexture rhs = scoreList[i].Rhs;
+
+                        List<GameObject> newGameObjects = new List<GameObject>(scoreList[i].Lhs.GameObjects.Concat(scoreList[i].Rhs.GameObjects));
+
+                        PackTexture newPackTexture = new PackTexture()
+                        {
+                            GameObjects = newGameObjects,
+                            Textures = unionTextures
+                        };
+
+                        
+                        packTextures.Remove(lhs);
+                        packTextures.Remove(rhs);
+                        packTextures.Add(newPackTexture);
+
+                        //Remove merged Score and make Score by new Pack Texture.
+                        scoreList.RemoveAll(score => score.Lhs == lhs || score.Lhs == rhs ||
+                                                     score.Rhs == lhs || score.Rhs == rhs );
+
+                        for (int j = 0; j < packTextures.Count - 1; ++j)
+                        {
+                            scoreList.Add(Score.GetScore(packTextures[j], newPackTexture));
+                        }
+
+                        scoreList.Sort((l, r) => r.Match - l.Match);
+
+                        //for start first loop
+                        i = -1;
+                    }
+                }
+
+                foreach (var pack in packTextures)
+                {
+                    yield return TextureAtlasModule.instance.GetTextureAtlas(pack.Textures.ToArray(), atlas =>
+                    {
+                        atlasGroups.Add(new AtlasGroup()
+                        {
+                            GameObjects = pack.GameObjects,
+                            Atlas = atlas
+                        });
+                    });
+                }
+                
+                Debug.Log("Packing count : " + maximum + ", textures : " + packTextures.Count);
+            }
+        }
+
+        private int GetMaximumTextureCount(int packTextureSize, int maxPieceSize, int textureCount)
+        {
+            int minTextureCount = packTextureSize / maxPieceSize;
+            //width * height
+            minTextureCount = minTextureCount * minTextureCount;
+
+            //we can't pack one texture.
+            //so, we should use half size texture.
+            while (minTextureCount < textureCount)
+                minTextureCount = minTextureCount * 4;
+
+            return minTextureCount;
+        }
+
+       
+    }
+
+}

--- a/Scripts/Editor/TexturePacker.cs
+++ b/Scripts/Editor/TexturePacker.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using UnityEngine;
 
@@ -207,7 +208,12 @@ namespace UnityEditor.Experimental.AutoLOD
 
             textureAtlas.Apply();
 
+            var name = Path.GetRandomFileName();
+            textureAtlas = SaveTexture(textureAtlas, name);
+
             atlas.textureAtlas = textureAtlas;
+
+            SaveUniqueAtlasAsset(atlas, name);
 
             return atlas;
         }
@@ -222,6 +228,11 @@ namespace UnityEditor.Experimental.AutoLOD
             {
                 textureImporter.isReadable = true;
                 textureImporter.SaveAndReimport();
+            }
+            else if (!assetImporter)
+            {
+                // In-memory textures need to be saved to disk in order to be referenced by the texture atlas
+                SaveUniqueAtlasAsset(texture, Path.GetRandomFileName());
             }
 
             int sideSize = Math.Max(texture.width, texture.height);
@@ -270,6 +281,42 @@ namespace UnityEditor.Experimental.AutoLOD
                 minTextureCount = minTextureCount * 4;
 
             return minTextureCount;
+        }
+
+        static Texture2D SaveTexture(Texture2D texture, string name)
+        {
+            var path = "AutoLOD/Generated/Atlases/" + name;
+            path = Path.ChangeExtension(path, "PNG");
+
+            var assetPath = "Assets/" + path;
+            var dataPath = Application.dataPath + "/" + path;
+
+            var dirPath = Path.GetDirectoryName(dataPath);
+            if (Directory.Exists(dirPath) == false)
+            {
+                Directory.CreateDirectory(dirPath);
+            }
+
+            byte[] binary = texture.EncodeToPNG();
+            File.WriteAllBytes(dataPath,binary);
+
+            AssetDatabase.ImportAsset(assetPath);
+            return AssetDatabase.LoadAssetAtPath<Texture2D>(assetPath);
+
+
+        }
+
+        static void SaveUniqueAtlasAsset(UnityEngine.Object asset, string name)
+        {
+            var directory = "Assets/AutoLOD/Generated/Atlases/";
+            if (!Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            var path = directory + name;
+            path = Path.ChangeExtension(path, "asset");
+            AssetDatabase.CreateAsset(asset, path);
+
+
         }
 
        

--- a/Scripts/Editor/TexturePacker.cs.meta
+++ b/Scripts/Editor/TexturePacker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b7183534e34d90469c298e5743b8166
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Interfaces/IBatcher.cs
+++ b/Scripts/Interfaces/IBatcher.cs
@@ -8,6 +8,6 @@ namespace UnityEngine.Experimental.AutoLOD
         /// Combine children renderers of this GameObject (NOTE: Runs as a coroutine)
         /// </summary>
         /// <param name="go">GameObject hierarchy to batch</param>
-        IEnumerator Batch(GameObject go);
+        IEnumerator Batch(GameObject hlodRoot);
     }
 }

--- a/Scripts/Utilities/DepthHolder.cs
+++ b/Scripts/Utilities/DepthHolder.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UnityEngine.Experimental.AutoLOD
+{
+    public class DepthHolder : MonoBehaviour
+    {
+        public int Depth { set; get; }
+    }
+
+}

--- a/Scripts/Utilities/DepthHolder.cs.meta
+++ b/Scripts/Utilities/DepthHolder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0096a0838f66f21409f60eb3eda19f93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
TextureAtlas is used to PNG.
  - It can save memory.  ( 1024 x 1024 : 10MB -> 2.4MB. In editor proflie )
  - Also, it can compress another format. eg, ETC2 or something.

Make limit texture size which will be included in the atlas.

Packing algorithm is not used which is inside the engine.