### PR TITLE
Features/hlod threshold size

### DIFF
--- a/Scripts/Editor/SceneLODCreator.cs
+++ b/Scripts/Editor/SceneLODCreator.cs
@@ -59,6 +59,8 @@ namespace Unity.AutoLOD
             public Type BatcherType;
             public IBatcher Batcher;
 
+            public float LODThresholdSize = 5.0f;
+
             public int LODTriangleMin = 10;
             public int LODTriangleMax = 500;
 
@@ -76,6 +78,8 @@ namespace Unity.AutoLOD
                 if ( BatcherType != null)
                     EditorPrefs.SetString(k_OptionStr + Name + ".BatcherType", BatcherType.AssemblyQualifiedName);
 
+                EditorPrefs.SetFloat(k_OptionStr + Name + "LODThresholdSize", LODThresholdSize);
+
                 EditorPrefs.SetInt(k_OptionStr + Name + "LODTriangleMin", LODTriangleMin);
                 EditorPrefs.SetInt(k_OptionStr + Name + "LODTriangleMax", LODTriangleMax);
                 
@@ -88,6 +92,8 @@ namespace Unity.AutoLOD
                 string batcherTypeStr = EditorPrefs.GetString(k_OptionStr + Name + ".BatcherType");
                 BatcherType = Type.GetType(batcherTypeStr);
                 Batcher = (IBatcher) Activator.CreateInstance(BatcherType, Name);
+
+                LODThresholdSize = EditorPrefs.GetFloat(k_OptionStr + Name + "LODThresholdSize", 5.0f);
 
                 LODTriangleMin = EditorPrefs.GetInt(k_OptionStr + Name + "LODTriangleMin", 10);
                 LODTriangleMax = EditorPrefs.GetInt(k_OptionStr + Name + "LODTriangleMax", 500);
@@ -341,11 +347,16 @@ namespace Unity.AutoLOD
             List<Renderer> hlodRenderers = new List<Renderer>();
             int depth = GetDepth(volumeBounds);
 
+            var groupOptions = m_Options.GroupOptions[volumeGroup.GroupName];
+
             foreach (var group in lodGroups)
             {
                 var lastLod = group.GetLODs().Last();
                 foreach (var lr in lastLod.renderers)
                 {
+                    float max = Mathf.Max(Mathf.Max(lr.bounds.size.x, lr.bounds.size.y), lr.bounds.size.z);
+                    if (max < groupOptions.LODThresholdSize)
+                        continue;
 
                     if (lr && lr.GetComponent<MeshFilter>())
                     {

--- a/Scripts/Editor/SceneLODCreator.cs
+++ b/Scripts/Editor/SceneLODCreator.cs
@@ -339,6 +339,10 @@ namespace Unity.AutoLOD
 
             lod.renderers = lodRenderers.ToArray();
             lodGroup.SetLODs(new LOD[] {detailLOD, lod});
+
+            //bounds is cuboid.
+            //it has the same size each axis.
+            lodGroup.size = volume.Bounds.size.x;
             yield break;
         }
 

--- a/Scripts/Editor/UI/GenerateSceneLODWindow.cs
+++ b/Scripts/Editor/UI/GenerateSceneLODWindow.cs
@@ -171,6 +171,7 @@ namespace Unity.AutoLOD
 
                     DrawBatcher(pair.Value);
                     DrawSimplification(pair.Value);
+                    DrawThreshold(pair.Value);
 
                     EditorGUI.indentLevel -= 1;
                 }
@@ -249,6 +250,10 @@ namespace Unity.AutoLOD
             groupOptions.LODTriangleMax = EditorGUILayout.IntSlider(Styles.LODTrangleMax, groupOptions.LODTriangleMax, 10, 5000);
 
             EditorGUI.indentLevel -= 1;
+        }
+        private void DrawThreshold(SceneLODCreator.GroupOptions groupOptions)
+        {
+            groupOptions.LODThresholdSize = EditorGUILayout.FloatField("LOD Threshold size", groupOptions.LODThresholdSize);
         }
 
 


### PR DESCRIPTION
Make a threshold.
  - HLOD is not necessary to a small object to make it.

Set the size in the LODGroup.
  - if there is no LODGroup in volume because of the threshold, it can be a cull by the too small size of LODGroup.